### PR TITLE
Esther/page refresh

### DIFF
--- a/Extension/background.js
+++ b/Extension/background.js
@@ -52,13 +52,26 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 // when a tab closes, if it's the tab with active history, clear history
 chrome.tabs.onRemoved.addListener(
-  (tabId) => {
-    if (tabId === currentTabId){
-      wipeHistory();
+  (tabId) => refreshHistoryConditionally(tabId, currentTabId)
+);
+
+/* when navigating to the page for any reason, if it's the tab with active */
+/* history, clear history; this conditional includes reload. */
+/* May want to always refresh history on any kind of re-access and replace */
+/* onRemoved? */
+chrome.webNavigation.onCommitted.addListener(
+  ({ tabId, transitionType }) => {
+    if (['reload'].includes(transitionType)) {
+      refreshHistoryConditionally(tabId, currentTabId)
     }
   }
-)
+);
 
-function wipeHistory () {
-  history = [];
+function refreshHistoryConditionally (tabId, currentTabId) {
+  if (tabId === currentTabId) {
+    console.log('wiping history');
+    history = [];
+    // send message to devTool store to reset
+    // could also reset startTime
+  }
 }

--- a/Extension/background.js
+++ b/Extension/background.js
@@ -1,6 +1,24 @@
 const connections = {};
 let history = [];
 let currentTabId;
+
+// when a tab closes, if it's the tab with active history, clear history
+//chrome.tabs.onRemoved.addListener(
+//  (tabId) => refreshHistoryConditionally(tabId, currentTabId)
+//);
+
+/* when navigating to the page for any reason, if it's the tab with active */
+/* history, clear history; this conditional includes reload. */
+/* May want to always refresh history on any kind of re-access and replace */
+/* onRemoved? */
+chrome.webNavigation.onCommitted.addListener(
+  ({ tabId, transitionType }) => {
+    if (['reload'].includes(transitionType)) {
+      refreshHistoryConditionally(tabId, currentTabId)
+    }
+  }
+);
+
 chrome.runtime.onConnect.addListener(function (port) {
     console.log('On connect add listener')
     const extensionListener = function (message, sender, sendResponse) {
@@ -9,7 +27,7 @@ chrome.runtime.onConnect.addListener(function (port) {
       if (message.name == "init") {
         currentTabId = message.tabId;
         connections[message.tabId] = port;
-        console.log('Sending history over for new connection')
+        console.log('Sending history over for new connection', history)
         history.forEach((request) => {
           connections[message.tabId].postMessage(request);
         });
@@ -31,6 +49,7 @@ chrome.runtime.onConnect.addListener(function (port) {
         }
     });
 });
+
 // Receive message from content script and relay to the devTools page for the current tab
 // content.js -> here -> devtool panel
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
@@ -39,7 +58,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (sender.tab) {
       const tabId = sender.tab.id;
       if (tabId in connections) {
-        // console.log("Background.js: posting message to devtool panel");
+        console.log("Background.js: posting message to devtool panel", history);
         connections[tabId].postMessage(request);
       } else {
         console.log("Tab not found in connection list.");
@@ -50,27 +69,11 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     return true;
 });
 
-// when a tab closes, if it's the tab with active history, clear history
-chrome.tabs.onRemoved.addListener(
-  (tabId) => refreshHistoryConditionally(tabId, currentTabId)
-);
-
-/* when navigating to the page for any reason, if it's the tab with active */
-/* history, clear history; this conditional includes reload. */
-/* May want to always refresh history on any kind of re-access and replace */
-/* onRemoved? */
-chrome.webNavigation.onCommitted.addListener(
-  ({ tabId, transitionType }) => {
-    if (['reload'].includes(transitionType)) {
-      refreshHistoryConditionally(tabId, currentTabId)
-    }
-  }
-);
-
 function refreshHistoryConditionally (tabId, currentTabId) {
   if (tabId === currentTabId) {
-    console.log('wiping history');
+    console.log('wiping history, of', history);
     history = [];
+    console.log('wiped to:', history)
     // send message to devTool store to reset
     // could also reset startTime
   }

--- a/Extension/background.js
+++ b/Extension/background.js
@@ -3,9 +3,9 @@ let history = [];
 let currentTabId;
 
 // when a tab closes, if it's the tab with active history, clear history
-//chrome.tabs.onRemoved.addListener(
-//  (tabId) => refreshHistoryConditionally(tabId, currentTabId)
-//);
+chrome.tabs.onRemoved.addListener(
+  (tabId) => refreshHistoryConditionally(tabId, currentTabId)
+);
 
 /* when navigating to the page for any reason, if it's the tab with active */
 /* history, clear history; this conditional includes reload. */
@@ -27,7 +27,7 @@ chrome.runtime.onConnect.addListener(function (port) {
       if (message.name == "init") {
         currentTabId = message.tabId;
         connections[message.tabId] = port;
-        console.log('Sending history over for new connection', history)
+//        console.log('Sending history over for new connection', history)
         history.forEach((request) => {
           connections[message.tabId].postMessage(request);
         });
@@ -58,7 +58,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (sender.tab) {
       const tabId = sender.tab.id;
       if (tabId in connections) {
-        console.log("Background.js: posting message to devtool panel", history);
+//        console.log("Background.js: posting message to devtool panel", history);
         connections[tabId].postMessage(request);
       } else {
         console.log("Tab not found in connection list.");
@@ -71,10 +71,17 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 function refreshHistoryConditionally (tabId, currentTabId) {
   if (tabId === currentTabId) {
-    console.log('wiping history, of', history);
+//    console.log('wiping history, of', history);
     history = [];
-    console.log('wiped to:', history)
+//    console.log('wiped to:', history)
     // send message to devTool store to reset
     // could also reset startTime
+    connections[tabId].postMessage({
+      source: 'vueable-query-extension',
+      payload: {
+        startTime: Date.now(),
+        type: 'resetHistory',
+      }
+    });
   }
 }

--- a/Extension/background.js
+++ b/Extension/background.js
@@ -54,7 +54,11 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 chrome.tabs.onRemoved.addListener(
   (tabId) => {
     if (tabId === currentTabId){
-      history = [];
+      wipeHistory();
     }
   }
 )
+
+function wipeHistory () {
+  history = [];
+}

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -10,7 +10,8 @@
   },
   "devtools_page": "devtools.html",
   "permissions": [
-    "tabs"
+    "tabs",
+    "webNavigation"
   ], 
   "web_accessible_resources": [{
     "resources": ["script.js"],

--- a/Extension/panel.html
+++ b/Extension/panel.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vueable Query Panel</title>
-    <script type="module" crossorigin src="/assets/main-a3a50126.js"></script>
+    <script type="module" crossorigin src="/assets/main-e87d5e85.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/Extension/panel.html
+++ b/Extension/panel.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vueable Query Panel</title>
-    <script type="module" crossorigin src="/assets/main-e87d5e85.js"></script>
+    <script type="module" crossorigin src="/assets/main-b303d619.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/Panel_TS_Vue_App/src/main.ts
+++ b/Panel_TS_Vue_App/src/main.ts
@@ -29,13 +29,12 @@ backgroundPageConnection.postMessage({
 backgroundPageConnection.onMessage.addListener((message: Message) => {
   console.log('got a message in main.ts: ', message)
   const { startTime, endTime, type, event } = message.payload;
-  if(type === 'pageStartTime'){
+  if(type === 'pageStartTime') {
     store.addPageStartTime(message.payload.startTime)
-  }
-  else{
+  } else if (type === 'resetHistory') {
+    store.resetHistory();
+  } else {
     console.log('main.ts: message received at its destination!', startTime, endTime, type, event.query.queryHash, message);
     store.addNewQuery(message);
   }
-    
-
 });

--- a/Panel_TS_Vue_App/src/store.ts
+++ b/Panel_TS_Vue_App/src/store.ts
@@ -27,6 +27,7 @@ export const useQueryStore = defineStore('query', () => {
 
   function addNewQuery(message: Message) {
     data.value.push(message);
+    console.log('added message to store', data.value);
   }
 
   function setSelection(index: number) {

--- a/Panel_TS_Vue_App/src/store.ts
+++ b/Panel_TS_Vue_App/src/store.ts
@@ -16,18 +16,21 @@ export const useQueryStore = defineStore('query', () => {
   const lastEndTime = computed<number>(()=>{
     //in the case that there is no queries yet
     if(data.value.length === 0) return 0;
-    console.log('lastEndTime: ', data.value[data.value.length - 1].payload.endTime - pageStartTime.value)
+//    console.log('lastEndTime: ', data.value[data.value.length - 1].payload.endTime - pageStartTime.value)
     return data.value[data.value.length - 1].payload.endTime - pageStartTime.value;
   })
 
   function addPageStartTime(time: number) {
     pageStartTime.value = time;
-    console.log('pageStartTime: ', pageStartTime.value)
+//    console.log('pageStartTime: ', pageStartTime.value)
   }
 
   function addNewQuery(message: Message) {
     data.value.push(message);
-    console.log('added message to store', data.value);
+  }
+
+  function resetHistory(): void {
+    data.value = [];
   }
 
   function setSelection(index: number) {
@@ -63,7 +66,7 @@ export const useQueryStore = defineStore('query', () => {
       }
       result[q.queryHash].push(q);
     })
-    return result
+    return result;
   })
 
   const keys = computed<string[]>(() => {
@@ -74,7 +77,7 @@ export const useQueryStore = defineStore('query', () => {
         result.push(q.queryHash)
       }
     })
-    return result
+    return result;
   })
   
   //filter by end
@@ -84,5 +87,5 @@ export const useQueryStore = defineStore('query', () => {
   const cacheQueries = computed<FormattedQuery[]>(() => queries.value.filter((obj):boolean => (obj.type === 'cache')));
 
 
-  return { keys, queries, addNewQuery, endQueries, cacheQueries, setSelection, setHoverSelection, selection, hoverSelection, addPageStartTime, lastEndTime, groupedQueries }
+  return { keys, queries, addNewQuery, resetHistory, endQueries, cacheQueries, setSelection, setHoverSelection, selection, hoverSelection, addPageStartTime, lastEndTime, groupedQueries }
 })


### PR DESCRIPTION
Pinia store persists past refresh, leading to negative start times and incorrectly persisted history.
Add new resetHistory action to reset store.data on reload.

resetHistory may need to fire on more event types (navigated to by link, for example).