### PR TITLE
Refresh on setPageStartTime, reduce permissions

### DIFF
--- a/Extension/background.ts
+++ b/Extension/background.ts
@@ -6,20 +6,7 @@ const histories: {
   [tabId: string]: Message[]
 } = {};
 
-// when a tab closes, if it's the tab with active history, clear history
-chrome.tabs.onRemoved.addListener(refreshHistoryConditionally);
 
-/* when navigating to the page for any reason, if it's the tab with active */
-/* history, clear history; this conditional includes reload. */
-/* May want to always refresh history on any kind of re-access and replace */
-/* onRemoved? */
-chrome.webNavigation.onCommitted.addListener(
-  ({ tabId, transitionType }) => {
-    if (['reload'].includes(transitionType)) {
-      refreshHistoryConditionally(tabId)
-    }
-  }
-);
 
 chrome.runtime.onConnect.addListener(function (port) { // listen for new ports
   const extensionListener = function ({ name, tabId }: {name: string, tabId: string}) { // listen for messages
@@ -67,20 +54,3 @@ chrome.runtime.onMessage.addListener(function(request, sender) {
   }
   return true;
 });
-
-function refreshHistoryConditionally (tabId: number) {
-  if (Object.prototype.hasOwnProperty.call(histories, tabId)) {
-    histories[tabId] = [];
-    // send message to devTool store to reset
-    // could also reset startTime
-    if (Object.prototype.hasOwnProperty.call(connections, tabId)) {
-      connections[tabId].postMessage({
-        source: 'vueable-query-extension',
-        payload: {
-          startTime: Date.now(),
-          type: 'resetHistory',
-        }
-      });
-    }
-  }
-}

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -1,14 +1,10 @@
 {
   "name": "Vueable Query", 
   "version": "1.0.0", 
-  "description": "This is an extension to monitor query completion time, cache hits/misses on the client side, graph visualization of data flow and subscribers to caches, includes a timeline for the sequence of queries, and report on query activities with a compilesWithDevTools model.",
+  "description": "This extension creates a Dev Tool Panel to monitor performance metrics for Vue apps that use Tanstack Query for Vue.",
   "manifest_version": 3,
   "author": "Anna Duong, Brandon Yoon, Eric Tjon, & Esther Witbeck",
   "devtools_page": "devtools.html",
-  "permissions": [
-    "tabs",
-    "webNavigation"
-  ], 
   "icons": {
     "128": "/assets/Vueable_Query_logo_128.png"
   },

--- a/Extension/script.ts
+++ b/Extension/script.ts
@@ -29,7 +29,7 @@ if(!(Object.prototype.hasOwnProperty.call(window, '__VUE__'))){ // check if Vue 
   // post messages to the window
   const callback = (event: Event) => {
     // new query (either fresh or after invalidation)
-    console.log(event.query.queryHash, event.type, event.action?.type, event.query.isStale());
+    // console.log(event.query.queryHash, event.type, event.action?.type, event.query.isStale());
 
     //for fetch requests
     if (event.type === 'updated' && event.action?.type === 'fetch') {

--- a/Panel/src/components/TimelineGraph.vue
+++ b/Panel/src/components/TimelineGraph.vue
@@ -198,7 +198,7 @@ const refreshGraph = (): void => {
     shapes.append("circle")
         //only add circles if rect shrink to at least 2px
         .filter(function(d) {
-            return (x(d.endTime) === x(d.startTime));
+            return (x(d.endTime) - x(d.startTime) <= 2);
         })
         .attr('cx', function(d) {
             //create var to hold the pixel width of the rect

--- a/Panel/src/main.ts
+++ b/Panel/src/main.ts
@@ -9,7 +9,6 @@ const pinia = createPinia();
 app.use(pinia);
 app.mount('#app');
 
-
 import { useQueryStore } from './store'
 const store = useQueryStore();
 
@@ -27,15 +26,11 @@ backgroundPageConnection.postMessage({
 //check querykey and messages for concurrent ones
 // background.js -> here
 backgroundPageConnection.onMessage.addListener((message: Message) => {
-//  console.log('got a message in main.ts: ', message)
+
   const { startTime, type} = message.payload;
   if(type === 'pageStartTime') {
     store.setPageStartTime(startTime)
-  } else if (type === 'resetHistory') {
-//    console.log('request to reset History');
-    store.resetHistory();
   } else {
-//    console.log('main.ts: message received at its destination!', startTime, endTime, type, event.query.queryHash, message);
     store.addNewQuery(message);
   }
 });

--- a/Panel/src/store.ts
+++ b/Panel/src/store.ts
@@ -14,6 +14,8 @@ export const useQueryStore = defineStore('query', () => {
   // ---setters---
   // setters can't be arrow functions
   function setPageStartTime(time: number): void {
+    // reset the history when we get a new start time
+    resetHistory();
     pageStartTime.value = time;
     // console.log('pageStartTime: ', pageStartTime.value)
   }


### PR DESCRIPTION
Replaced the refresh occurring in background script with refreshing the pinia store on setPageStartTime.
Works the same, but now we have less chrome extension permissions (tab and webNavigation) so its easier to publish.